### PR TITLE
ci: use reusable workflow from IndrajeetPatil/workflows

### DIFF
--- a/.github/workflows/build-presentation.yaml
+++ b/.github/workflows/build-presentation.yaml
@@ -7,49 +7,9 @@ on:
     branches: [main, master]
 
 jobs:
-  build-presentation:
-    runs-on: macos-latest
+  build-and-deploy:
+    uses: IndrajeetPatil/workflows/.github/workflows/build-presentation-r.yaml@main
+    with:
+      runner-os: macos-latest
     permissions:
       contents: write
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-        with:
-          pandoc-version: "latest"
-
-      - name: Setup Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: pre-release
-
-      - name: Install Quarto extensions
-        run: |
-          quarto --version
-          quarto install extension quarto-ext/fontawesome --no-prompt
-
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          pak-version: devel
-          upgrade: "TRUE"
-
-      - name: Render slides
-        run: quarto render index.qmd
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
-        with:
-          branch: docs
-          folder: .
-          clean: true


### PR DESCRIPTION
## Summary

Replaces the standalone `build-presentation.yaml` workflow with a call to the reusable workflow in [IndrajeetPatil/workflows](https://github.com/IndrajeetPatil/workflows).

### Changes
- `build-presentation.yaml`: Replaced with call to `build-presentation-r.yaml` reusable workflow
- macOS runner preserved via `runner-os: macos-latest` input
- All actions now pinned to SHA for supply chain security

### Benefits
- Centralized workflow maintenance — changes only need to be made once
- All actions pinned to SHA for supply chain security
- Consistent CI/CD across all presentation repos

### Note on `@main` references

The caller workflows reference `IndrajeetPatil/workflows` via `@main` rather than a pinned SHA. This is intentional — all third-party GitHub Actions within the reusable workflows are already pinned to specific commit SHAs (e.g., `actions/checkout@de0fac2...`, `r-lib/actions@6f6e5bc...`). Since the workflows repository is under the same owner's control, there is no third-party supply chain risk. This follows the same pattern used by [easystats/workflows](https://github.com/easystats/workflows).