### PR TITLE
refactor: switch mermaid from PNG to JS rendering, use ubuntu

### DIFF
--- a/.github/workflows/build-presentation.yaml
+++ b/.github/workflows/build-presentation.yaml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-and-deploy:
     uses: IndrajeetPatil/workflows/.github/workflows/build-presentation-r.yaml@main
-    with:
-      runner-os: macos-latest
     permissions:
       contents: read
       pages: write

--- a/index.qmd
+++ b/index.qmd
@@ -11,7 +11,6 @@ format:
     help: true
     include-in-header: meta-tags.html
     link-external-newwindow: true
-    mermaid-format: png
 revealjs-plugins:
   - fontawesome
 execute:


### PR DESCRIPTION
## Summary

Switch mermaid diagram rendering from server-side PNG (requiring chromote/chromium on macOS) to default client-side JS/SVG rendering, enabling consistent `ubuntu-latest` builds.

## Changes

- **Remove `mermaid-format: png`** from `index.qmd` YAML header — diagrams will render as JS/SVG client-side in the browser
- **Remove `runner-os: macos-latest`** from workflow — no longer needed without PNG rendering

## Why this works

`intro-to-ggstatsplot` already renders 2 mermaid blocks using default JS rendering on ubuntu-latest successfully, confirming this approach works.

## Companion PR

- [IndrajeetPatil/workflows#3](https://github.com/IndrajeetPatil/workflows/pull/3) — removes the `runner-os` input from the shared workflow