### PR TITLE
chore: replace old GitHub Pages domain with new custom domain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.2
 URL: https://github.com/IndrajeetPatil/dry-r-package-development/,
-    https://indrajeetpatil.github.io/dry-r-package-development/
+    https://www.indrapatil.com/dry-r-package-development/
 BugReports: https://github.com/IndrajeetPatil/dry-r-package-development/issues
 Depends:
     knitr,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ violating the DRY (Don't Repeat Yourself) Principle in
 - conditions
 
 Link to slides:
-<https://indrajeetpatil.github.io/dry-r-package-development/>
+<https://www.indrapatil.com/dry-r-package-development/>
 
 <img src="media/simpsons.png" width="50%" alt="Simpsons cartoon where a character is writing on the blackboard that they will not repeat themselves while repeating themselves by writing the same thing again and again" />
 

--- a/index.qmd
+++ b/index.qmd
@@ -26,7 +26,7 @@ lang: "en"
 dir: "ltr"
 image: "media/social-media-card.png"
 image-alt: "Preview image for presentation about DRY (Don't Repeat Yourself) principle in R package development"
-canonical-url: "https://indrajeetpatil.github.io/dry-r-package-development/"
+canonical-url: "https://www.indrapatil.com/dry-r-package-development/"
 ---
 
 ## DRY Package Development in R {style="text-align: center;"}
@@ -1633,7 +1633,7 @@ And Happy (DRY) Package Development! 😊
 
 ::: {style="text-align: center; font-size: 0.7em;"}
 
-Check out my other [slide decks](https://indrajeetpatil.github.io/presentations/) on software development best practices
+Check out my other [slide decks](https://www.indrapatil.com/presentations/) on software development best practices
 
 :::
 

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -23,11 +23,11 @@
 />
 <meta
   property="og:image"
-  content="https://indrajeetpatil.github.io/dry-r-package-development/media/social-media-card.png"
+  content="https://www.indrapatil.com/dry-r-package-development/media/social-media-card.png"
 />
 <meta
   property="og:url"
-  content="https://indrajeetpatil.github.io/dry-r-package-development/"
+  content="https://www.indrapatil.com/dry-r-package-development/"
 />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary_large_image" />
@@ -41,5 +41,5 @@
 />
 <meta
   name="twitter:image"
-  content="https://indrajeetpatil.github.io/dry-r-package-development/media/social-media-card.png"
+  content="https://www.indrapatil.com/dry-r-package-development/media/social-media-card.png"
 />


### PR DESCRIPTION
## Summary

This PR updates all references from the old GitHub Pages domain to the new custom domain:

- **Old**: `https://indrajeetpatil.github.io/`
- **New**: `https://www.indrapatil.com/`

This is part of a bulk domain migration across all repositories.